### PR TITLE
Adds datadog-ci and quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
           DATABASE_URL: ${{ env.DATABASE_URL }}
           NEXT_PUBLIC_QUOTES_API_URL: ${{ env.QUOTES_API_URL }}
           NODE_OPTIONS: -r ${{env.DD_TRACE_PACKAGE}}
+        
+      - name: Run Quality Gate
+        if: always()
+        run: npx datadog-ci gate evaluate    
 
       - name: Save npm cache
         uses: actions/cache/save@v4


### PR DESCRIPTION
This PR adds datadog-ci and a quality gate to the repository to prevent flaky tests from being merged into the codebase.